### PR TITLE
Add Smithery to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,20 @@
 # Coincap MCP
+[![smithery badge](https://smithery.ai/badge/coincap-mcp)](https://smithery.ai/server/coincap-mcp)
 
 ## What does this server do?
 
 Allows you to query crypto information from coincap's public API - no API keys or registration required
 
 ## 🚀 Quick Start
+### Installing via Smithery
 
+To install Coincap for Claude Desktop automatically via [Smithery](https://smithery.ai/server/coincap-mcp):
+
+```bash
+npx -y @smithery/cli install coincap-mcp --client claude
+```
+
+### Installing Manually
 To get started, add this configuration to your Claude Desktop config file:
 
 **MacOS**: `~/Library/Application\ Support/Claude/claude_desktop_config.json`  


### PR DESCRIPTION
This PR makes two changes to the README.

1. Adds installation instructions to automatically install Coincap for Claude Desktop using Smithery CLI. This makes it easier for users to install the MCP.
2. Adds a badge to show the number of installations from Smithery: https://smithery.ai/server/coincap-mcp

Let me know if any tweaks have to be made!