### PR TITLE
Migrate from deprecated CoinCap v2 to v3 API

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,15 @@
 
 ## What does this server do?
 
-Allows you to query crypto information from coincap's public API - no API keys or registration required
+Allows you to query crypto information from the CoinCap v3 API — real-time prices, market caps, and asset data for 1,000+ cryptocurrencies.
 
 ## 🚀 Quick Start
 
-To get started, add this configuration to your Claude Desktop config file:
+### 1. Get an API Key
+
+CoinCap v3 requires authentication. Get a free key (50 credits) at [pro.coincap.io/dashboard](https://pro.coincap.io/dashboard).
+
+### 2. Configure Claude Desktop
 
 **MacOS**: `~/Library/Application\ Support/Claude/claude_desktop_config.json`  
 **Windows**: `%APPDATA%/Claude/claude_desktop_config.json`
@@ -16,9 +20,12 @@ To get started, add this configuration to your Claude Desktop config file:
 ```json
 {
   "mcpServers": {
-    "mongodb": {
+    "coincap-mcp": {
       "command": "npx",
-      "args": ["coincap-mcp"]
+      "args": ["coincap-mcp"],
+      "env": {
+        "COINCAP_API_KEY": "your-api-key-here"
+      }
     }
   }
 }
@@ -36,8 +43,15 @@ npx -y @smithery/cli install coincap-mcp --client claude
 
 - Node.js 18+
 - npx
+- CoinCap API key (free tier available)
 
 Then, launch Claude Desktop and you're ready to go!
+
+## Environment Variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `COINCAP_API_KEY` | Yes | CoinCap v3 API key. Get one free at [pro.coincap.io](https://pro.coincap.io/dashboard) |
 
 ## Sample Prompts
 
@@ -53,11 +67,11 @@ Gets price for Bitcoin specifically, it's a simple example of a primitive API ca
 
 #### Get Crypto Price Tool
 
-Gets price for any cryptocurrency available on coincap API. It's a good example of how to get mandatory parameter data for your tool calls
+Gets price for any cryptocurrency available on CoinCap API. It's a good example of how to get mandatory parameter data for your tool calls
 
 #### List Assets
 
-Gets a list of all crypto assets available in coincap API
+Gets a list of all crypto assets available in the CoinCap API
 
 ## Development - local build
 
@@ -70,7 +84,10 @@ On Windows: `%APPDATA%/Claude/claude_desktop_config.json`
 {
   "mcpServers": {
     "coincap-mcp": {
-      "command": "/path/to/coincap-mcp/build/index.js"
+      "command": "/path/to/coincap-mcp/build/index.js",
+      "env": {
+        "COINCAP_API_KEY": "your-api-key-here"
+      }
     }
   }
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,32 @@
-export const BITCOIN_PRICE_URL = "https://api.coincap.io/v2/assets/bitcoin";
+export const COINCAP_BASE_URL = "https://rest.coincap.io/v3";
 export const CONSTANTS = {
-  CRYPTO_PRICE_URL: "https://api.coincap.io/v2/assets/",
+  CRYPTO_PRICE_URL: `${COINCAP_BASE_URL}/assets/`,
+  BITCOIN_PRICE_URL: `${COINCAP_BASE_URL}/assets/bitcoin`,
+  LIST_ASSETS_URL: `${COINCAP_BASE_URL}/assets`,
   PROJECT_NAME: "coincap-mcp",
-  PROJECT_VERSION: "0.9.2",
+  PROJECT_VERSION: "1.0.0",
 };
+
+/**
+ * Get the CoinCap API key from environment.
+ * V3 requires authentication. Get a free key (50 credits) at:
+ * https://pro.coincap.io/dashboard
+ * Or create one programmatically via POST https://rest.coincap.io/v3/prepaid/create
+ */
+export function getApiKey(): string | undefined {
+  return process.env.COINCAP_API_KEY;
+}
+
+/**
+ * Build headers for CoinCap v3 API requests.
+ */
+export function getHeaders(): Record<string, string> {
+  const key = getApiKey();
+  const headers: Record<string, string> = {
+    "Accept": "application/json",
+  };
+  if (key) {
+    headers["Authorization"] = `Bearer ${key}`;
+  }
+  return headers;
+}

--- a/src/tools/BitcoinPrice.ts
+++ b/src/tools/BitcoinPrice.ts
@@ -1,5 +1,5 @@
 import { Tool } from "@modelcontextprotocol/sdk/types.js";
-import { BITCOIN_PRICE_URL } from "../constants.js";
+import { CONSTANTS, getHeaders } from "../constants.js";
 import { BaseToolImplementation } from "./BaseTool.js";
 
 class BitcoinPriceTool extends BaseToolImplementation {
@@ -14,20 +14,32 @@ class BitcoinPriceTool extends BaseToolImplementation {
 
   toolCall = async () => {
     try {
-      const response = await fetch(BITCOIN_PRICE_URL);
+      const response = await fetch(CONSTANTS.BITCOIN_PRICE_URL, {
+        headers: getHeaders(),
+      });
+      if (response.status === 401 || response.status === 403) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: "Authentication required. Set COINCAP_API_KEY environment variable. Get a free key at https://pro.coincap.io/dashboard",
+            },
+          ],
+        };
+      }
       if (!response.ok) {
-        throw new Error("Error fetching coincap data");
+        throw new Error(`CoinCap API error: ${response.status} ${response.statusText}`);
       }
 
       const body = await response.json();
 
       return {
-        content: [{ type: "text", text: `${JSON.stringify(body.data)}` }],
+        content: [{ type: "text", text: JSON.stringify(body.data) }],
       };
     } catch (error) {
       return {
         content: [
-          { type: "error", text: JSON.stringify((error as any).message) },
+          { type: "text", text: `Error: ${(error as any).message}` },
         ],
       };
     }

--- a/src/tools/GetCryptoPrice.ts
+++ b/src/tools/GetCryptoPrice.ts
@@ -1,5 +1,5 @@
 import { Tool } from "@modelcontextprotocol/sdk/types.js";
-import { CONSTANTS } from "../constants.js";
+import { CONSTANTS, getHeaders } from "../constants.js";
 import { z } from "zod";
 import { CallToolRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import { BaseToolImplementation } from "./BaseTool.js";
@@ -8,13 +8,13 @@ class GetCryptoPrice extends BaseToolImplementation {
   name = "get_crypto_price";
   toolDefinition: Tool = {
     name: this.name,
-    description: "Get realtime crypto price on crypto",
+    description: "Get realtime crypto price",
     inputSchema: {
       type: "object",
       properties: {
         name: {
           type: "string",
-          description: "Name of the crypto coin",
+          description: "Name of the crypto coin (slug, e.g. bitcoin, ethereum)",
         },
       },
     },
@@ -28,9 +28,19 @@ class GetCryptoPrice extends BaseToolImplementation {
       }
       const url = CONSTANTS.CRYPTO_PRICE_URL + cryptoName;
 
-      const response = await fetch(url);
+      const response = await fetch(url, { headers: getHeaders() });
+      if (response.status === 401 || response.status === 403) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: "Authentication required. Set COINCAP_API_KEY environment variable. Get a free key at https://pro.coincap.io/dashboard",
+            },
+          ],
+        };
+      }
       if (!response.ok) {
-        throw new Error("Error fetching coincap data");
+        throw new Error(`CoinCap API error: ${response.status} ${response.statusText}`);
       }
 
       const body = await response.json();
@@ -41,7 +51,7 @@ class GetCryptoPrice extends BaseToolImplementation {
     } catch (error) {
       return {
         content: [
-          { type: "error", text: JSON.stringify((error as any).message) },
+          { type: "text", text: `Error: ${(error as any).message}` },
         ],
       };
     }

--- a/src/tools/ListAssets.ts
+++ b/src/tools/ListAssets.ts
@@ -1,24 +1,41 @@
 import { Tool } from "@modelcontextprotocol/sdk/types.js";
-import { CONSTANTS } from "../constants.js";
+import { CONSTANTS, getHeaders } from "../constants.js";
 import { BaseToolImplementation } from "./BaseTool.js";
 
 class ListAssetsTool extends BaseToolImplementation {
   name = "list_assets";
   toolDefinition: Tool = {
     name: this.name,
-    description: "Get all available crypto assets",
+    description: "Get all available crypto assets with market data",
     inputSchema: {
       type: "object",
+      properties: {
+        limit: {
+          type: "number",
+          description: "Number of assets to return (default: 100)",
+        },
+      },
     },
   };
 
-  toolCall = async () => {
+  toolCall = async (request?: any) => {
     try {
-      const url = CONSTANTS.CRYPTO_PRICE_URL;
+      const limit = request?.params?.arguments?.limit || 100;
+      const url = `${CONSTANTS.LIST_ASSETS_URL}?limit=${limit}`;
 
-      const response = await fetch(url);
+      const response = await fetch(url, { headers: getHeaders() });
+      if (response.status === 401 || response.status === 403) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: "Authentication required. Set COINCAP_API_KEY environment variable. Get a free key at https://pro.coincap.io/dashboard",
+            },
+          ],
+        };
+      }
       if (!response.ok) {
-        throw new Error("Error fetching coincap data");
+        throw new Error(`CoinCap API error: ${response.status} ${response.statusText}`);
       }
 
       const body = await response.json();
@@ -29,7 +46,7 @@ class ListAssetsTool extends BaseToolImplementation {
     } catch (error) {
       return {
         content: [
-          { type: "error", text: JSON.stringify((error as any).message) },
+          { type: "text", text: `Error: ${(error as any).message}` },
         ],
       };
     }


### PR DESCRIPTION
Fixes #5 — all three tools (`list_assets`, `get_crypto_price`, `bitcoin_price`) are broken because CoinCap deprecated their v2 API on March 31, 2025.

## Changes

- **`constants.ts`** — Updated base URL from `api.coincap.io/v2` to `rest.coincap.io/v3`. Added `getApiKey()` and `getHeaders()` helpers for v3 authentication.
- **`ListAssets.ts`** — Uses v3 endpoint with auth headers. Added `limit` parameter. Returns clear message if API key is missing.
- **`GetCryptoPrice.ts`** — Uses v3 endpoint with auth headers. Same auth error handling.
- **`BitcoinPrice.ts`** — Uses v3 endpoint with auth headers. Same auth error handling.
- **`README.md`** — Documents the `COINCAP_API_KEY` environment variable and how to get a free key (50 credits at pro.coincap.io).

## Breaking change

CoinCap v3 requires an API key (v2 was unauthenticated). Free keys with 50 credits are available at https://pro.coincap.io/dashboard — no credit card needed. The `COINCAP_API_KEY` env var needs to be set in the MCP server config.

## Testing

Verified v3 endpoints respond correctly with a prepaid API key:
```
POST https://rest.coincap.io/v3/prepaid/create → 50 free credits
GET  https://rest.coincap.io/v3/assets?limit=2  → asset data
GET  https://rest.coincap.io/v3/assets/bitcoin   → BTC data
```